### PR TITLE
Unique secondaryID

### DIFF
--- a/server/models/counsellingService.model.ts
+++ b/server/models/counsellingService.model.ts
@@ -89,19 +89,9 @@ const CounsellingServiceSchema = new mongoose.Schema<CounsellingServiceDoc>({
     secondaryID: {
         type: String,
         required: false,
-        index: true
-
+        unique: true
     },
-
 });
-
-
-CounsellingServiceSchema.index({ secondaryID: 1 } ); // index
-
-//CounsellingServiceSchema.index({ secondaryID: 1 }, { unique: true }); // index
-//db.CounsellingServiceSchema.createIndexes({ secondaryID: 1 }, { unique: true }); // index
-
-
 
 // attach as static function of the schema
 CounsellingServiceSchema.statics.build = (attr: ICounsellingService) => {
@@ -109,3 +99,8 @@ CounsellingServiceSchema.statics.build = (attr: ICounsellingService) => {
 };
 
 export const CounsellingService: ICounsellingServiceModel = mongoose.model<CounsellingServiceDoc,ICounsellingServiceModel>('CounsellingService', CounsellingServiceSchema);
+
+CounsellingService.on('index', error => {
+    // If there is an error with creating an index, this will be logged here
+    if (error) console.log(error);
+});

--- a/server/models/counsellingService.model.ts
+++ b/server/models/counsellingService.model.ts
@@ -21,7 +21,6 @@ interface ICounsellingService {
 // when create new doc in db mongoose returns additional info
 // this interface captures that
 interface CounsellingServiceDoc extends mongoose.Document, ICounsellingService {
-    //collation: any
 }
 
 // add build function to model
@@ -86,17 +85,23 @@ const CounsellingServiceSchema = new mongoose.Schema<CounsellingServiceDoc>({
         type: String,
         required: true
     },
+
     secondaryID: {
         type: String,
-        required: false
+        required: false,
+        index: true
+
     },
-}, 
-{
-    collation: { 
-        locale: 'en', 
-        strength: 2 
-    }
+
 });
+
+
+CounsellingServiceSchema.index({ secondaryID: 1 } ); // index
+
+//CounsellingServiceSchema.index({ secondaryID: 1 }, { unique: true }); // index
+//db.CounsellingServiceSchema.createIndexes({ secondaryID: 1 }, { unique: true }); // index
+
+
 
 // attach as static function of the schema
 CounsellingServiceSchema.statics.build = (attr: ICounsellingService) => {


### PR DESCRIPTION
## Description
#### Summary:
This PR contains a small change to the schema to make the counselling service `secondaryID` a unique field. Note that if the database already contains services without a `secondaryID`, then MongoDB won't be able to build a unique index successfully, causing duplicates to occur in the database.

#### Changes:
- Added a ```unique``` property to the ```secondaryID``` field in the Mongoose schema

#### How to test this PR:
- Use a database that doesn't contain entries without a secondaryID. You can create a new database for this, or use the ```test_db``` database that I created.
- To switch the database you're using, change the database name in the ```.env``` file. The connection string should be formatted like ```mongodb+srv://<USER>:<PASSWORD>@cluster0.goe5y.mongodb.net/<DATABASE_NAME>?retryWrites=true&w=majority```.
- Use the POST request to try to add the same service multiple times. The request should fail with an error message on the first and subsequent tries where there is a duplicate. The error message should be the same as the one in the screenshot below.

<img width="1036" alt="Screen Shot 2022-06-27 at 3 59 32 PM" src="https://user-images.githubusercontent.com/57027339/176057355-ac9a3607-d725-4645-b32a-3b8063173b18.png">



## Screenshots:
  
  
