### PR TITLE
Add remaining filters

### DIFF
--- a/server/controllers/counselling-service.controller.ts
+++ b/server/controllers/counselling-service.controller.ts
@@ -4,7 +4,18 @@ import CSService from '../services/counselling-service.service';
 
 async function getCounsellingServices(req: Request, res: Response) {  
     try {
-      const services = await CSService.getCounsellingServices(req.query.school, req.query.isOfferedOnline, req.query.urgency, req.query.specialty);
+      const services = await CSService.getCounsellingServices(req.query.serviceName,
+                                                              req.query.location,
+                                                              req.query.school,
+                                                              req.query.organization, 
+                                                              req.query.serviceType,
+                                                              req.query.urgency, 
+                                                              req.query.targetClients,
+                                                              req.query.isAllDay,
+                                                              req.query.specialty,
+                                                              req.query.deliveryMethod,
+                                                              req.query.description);
+      // const services = await CSService.getCounsellingServices(req.query.serviceName, req.query.location, req.query.school, req.query.organization, req.query.serviceType, req.query.urgency, req.query.targetClients, req.query.isAllDay, req.query.specialty, req.query.delivery, req.query.description);
       res.json(services);
     } catch (err: any) {
       // send status code 500 with message to client (means server's fault)

--- a/server/controllers/counselling-service.controller.ts
+++ b/server/controllers/counselling-service.controller.ts
@@ -13,7 +13,7 @@ async function getCounsellingServices(req: Request, res: Response) {
                                                               req.query.targetClients,
                                                               req.query.isAllDay,
                                                               req.query.specialty,
-                                                              req.query.deliveryMethod,
+                                                              req.query.delivery,
                                                               req.query.description);
       // const services = await CSService.getCounsellingServices(req.query.serviceName, req.query.location, req.query.school, req.query.organization, req.query.serviceType, req.query.urgency, req.query.targetClients, req.query.isAllDay, req.query.specialty, req.query.delivery, req.query.description);
       res.json(services);

--- a/server/route.rest
+++ b/server/route.rest
@@ -3,7 +3,7 @@
 GET http://localhost:4000/counselling-services
 
 ###
-GET http://localhost:4000/counselling-services?serviceName=sap
+GET http://localhost:4000/counselling-services?delivery=app
 
 ###
 GET http://localhost:4000/counselling-services?isOfferedOnline=true&school=UBC

--- a/server/route.rest
+++ b/server/route.rest
@@ -3,7 +3,7 @@
 GET http://localhost:4000/counselling-services
 
 ###
-GET http://localhost:4000/counselling-services?school=uBc
+GET http://localhost:4000/counselling-services?serviceName=sap
 
 ###
 GET http://localhost:4000/counselling-services?isOfferedOnline=true&school=UBC
@@ -53,7 +53,46 @@ Content-Type: application/json
 }
 
 ###
-DELETE http://localhost:4000/counselling-services/6222ae68c10113e79aea0871
+POST http://localhost:4000/counselling-services
+Content-Type: application/json
+
+{
+    "serviceName": "Student test",
+    "school": "SFU",
+    "location": "Vancouver",
+    "organization": "Test",
+    "serviceType": [
+        "Counselling",
+        "Medical"
+    ],
+    "urgency": "Same Day",
+    "targetClients": [
+        "SFU students"
+    ],
+    "isAllDay": false,
+    "website": "https://students.ubc.ca/health/ubc-student-assistance-program-sap",
+    "specialty": [
+        "Stress",
+        "Anxiety",
+        "Depression",
+        "Addiction",
+        "Crisis",
+        "Grief",
+        "Trauma",
+        "Fitness",
+        "Nutrition",
+        "Sleep"
+    ],
+    "isOfferedOnline": true,
+    "delivery": [
+        "Online",
+        "Phone"
+    ],
+    "description": "test"
+}
+
+###
+DELETE http://localhost:4000/counselling-services/62c23ea0246374345e9ded70
 
 ###
 PATCH http://localhost:4000/counselling-services/6223e2b28bae61f01f2ab573

--- a/server/services/counselling-service.service.ts
+++ b/server/services/counselling-service.service.ts
@@ -1,30 +1,99 @@
 import { CounsellingService, ICounsellingService } from '../models/counsellingService.model';
 
-async function getCounsellingServices(schoolQuery: any, onlineQuery: any, urgencyQuery: any, specialtyQuery: any): Promise<ICounsellingService[]> {
-    // TODO: Move input validation to controller
+async function getCounsellingServices(nameQuery: any,
+                                      locationQuery: any,
+                                      schoolQuery: any, 
+                                      organizationQuery: any,
+                                      serviceTypeQuery: any,
+                                      urgencyQuery: any, 
+                                      targetClientsQuery: any,
+                                      isAllDayQuery: any,
+                                      specialtyQuery: any,
+                                      deliveryQuery: any,
+                                      descriptionQuery: any): Promise<ICounsellingService[]> {
+  // TODO: Move input validation to controller
 
-    const school = schoolQuery ? { school: schoolQuery } : {};
-    const isOfferedOnline = onlineQuery ? { isOfferedOnline: onlineQuery } : {};
-    const urgency = urgencyQuery ? { urgency: { $regex: urgencyQuery, $options: 'i' } } : {};
+  const serviceName = nameQuery ? { serviceName: { $regex: nameQuery, $options: 'i' } } : {};
+  const location = locationQuery ? { location: { $regex: locationQuery, $options: 'i' } } : {};
+  const school = schoolQuery ? { school: { $regex: schoolQuery, $options: 'i' } } : {};
+  const organization = organizationQuery ? { organization: { $regex: organizationQuery, $options: 'i' } } : {};
+  const urgency = urgencyQuery ? { urgency: { $regex: urgencyQuery, $options: 'i' } } : {};
+  const isAllDay = (isAllDayQuery != null) ? { isAllDay: isAllDayQuery } : {};
+  const description = descriptionQuery ? { description: { $regex: descriptionQuery, $options: 'i' } } : {};
+
+  const optRegexpServiceType : RegExp[] = [];
+  if (serviceTypeQuery && Array.isArray(serviceTypeQuery)) {
+    (serviceTypeQuery as string[]).forEach(function(opt: string) {
+      optRegexpServiceType.push( new RegExp(opt, "i") );
+    }); 
+  }
+
+  const serviceType = serviceTypeQuery ? 
+    optRegexpServiceType.length == 0 ? 
+      { serviceType: {$regex: serviceTypeQuery, $options: 'i'} }
+      : 
+      { serviceType: {$in: optRegexpServiceType} }
+    :
+    {};
+
+  const optRegexpTargetClients : RegExp[] = [];
+  if (targetClientsQuery && Array.isArray(targetClientsQuery)) {
+    (targetClientsQuery as string[]).forEach(function(opt: string) {
+      optRegexpTargetClients.push( new RegExp(opt, "i") );
+    }); 
+  }
+
+  const targetClients = targetClientsQuery ? 
+    optRegexpTargetClients.length == 0 ? 
+      { targetClients: {$regex: targetClientsQuery, $options: 'i'} }
+      : 
+      { targetClients: {$in: optRegexpTargetClients} }
+    :
+    {};
+
+  const optRegexpSpecialty : RegExp[] = [];
+  if (specialtyQuery && Array.isArray(specialtyQuery)) {
+    (specialtyQuery as string[]).forEach(function(opt: string) {
+      optRegexpSpecialty.push( new RegExp(opt, "i") );
+    }); 
+  }
   
-    const optRegexp: RegExp[] = [];
-    if (specialtyQuery && Array.isArray(specialtyQuery)) {
-      (specialtyQuery as string[]).forEach(function (opt: string) {
-        optRegexp.push(new RegExp(opt, "i"));
-      });
-    }
-  
-    const specialty = specialtyQuery ?
-      optRegexp.length == 0 ?
-        { specialty: { $regex: specialtyQuery, $options: 'i' } }
-        :
-        { specialty: { $in: optRegexp } }
-      :
-      {};
+  const specialty = specialtyQuery ? 
+    optRegexpSpecialty.length == 0 ? 
+      { specialty: {$regex: specialtyQuery, $options: 'i'} }
+      : 
+      { specialty: {$in: optRegexpSpecialty} }
+  :
+  {};
 
-    const services = await CounsellingService.find({ $and: [{ ...school, ...isOfferedOnline, ...specialty, ...urgency }] }).collation({ locale: 'en', strength: 2 }).lean();
+  const optRegexpDeliveryMethod : RegExp[] = [];
+  if (deliveryQuery && Array.isArray(deliveryQuery)) {
+    (deliveryQuery as string[]).forEach(function(opt: string) {
+      optRegexpDeliveryMethod.push( new RegExp(opt, "i") );
+    }); 
+  }
 
-    return services;
+  const deliveryMethod = deliveryQuery ? 
+    optRegexpDeliveryMethod.length == 0 ? 
+      { deliveryMethod: {$regex: deliveryQuery, $options: 'i'} }
+      : 
+      { deliveryMethod: {$in: optRegexpDeliveryMethod} }
+    :
+    {};
+
+  const services = await CounsellingService.find({ $and: [{ ...serviceName, 
+                                                            ...location,
+                                                            ...school, 
+                                                            ...organization,
+                                                            ...serviceType,
+                                                            ...specialty, 
+                                                            ...urgency,
+                                                            ...targetClients,
+                                                            ...isAllDay,
+                                                            ...deliveryMethod,
+                                                            ...description}] }).collation({ locale: 'en', strength: 2 }).lean();
+
+  return services;
 }
 
 async function getCounsellingService(id: string): Promise<ICounsellingService> {

--- a/server/services/counselling-service.service.ts
+++ b/server/services/counselling-service.service.ts
@@ -73,11 +73,11 @@ async function getCounsellingServices(nameQuery: any,
     }); 
   }
 
-  const deliveryMethod = deliveryQuery ? 
+  const delivery = deliveryQuery ? 
     optRegexpDeliveryMethod.length == 0 ? 
-      { deliveryMethod: {$regex: deliveryQuery, $options: 'i'} }
+      { delivery: {$regex: deliveryQuery, $options: 'i'} }
       : 
-      { deliveryMethod: {$in: optRegexpDeliveryMethod} }
+      { delivery: {$in: optRegexpDeliveryMethod} }
     :
     {};
 
@@ -90,7 +90,7 @@ async function getCounsellingServices(nameQuery: any,
                                                             ...urgency,
                                                             ...targetClients,
                                                             ...isAllDay,
-                                                            ...deliveryMethod,
+                                                            ...delivery,
                                                             ...description}] }).collation({ locale: 'en', strength: 2 }).lean();
 
   return services;


### PR DESCRIPTION
## Description
#### Summary:
Adds remaining filtering fields from the new schema.

#### Changes:
- Add serviceName, location, organization, isAllDay, serviceType, targetClients, delivery, and description as parameters in counselling-service.controller.ts and their corresponding queries as parameters in counselling-service.service.ts
- Implement filtering for the above fields in counselling-service.service.ts

#### How to test this PR:
1. Connect to the test database "filter_tests" by changing the database name in the .env file. The connection string should look like: mongodb+srv://:@cluster0.goe5y.mongodb.net/<DATABASE_NAME>?retryWrites=true&w=majority.
2. Send and modify the GET requests in route.rest to filter the 3 services currently in the database by each field. Filtering should be case insensitive for all fields, and for string fields should behave like "contains" (e.g. serviceName=SAP should return the service with SAP in the name).