### PR TITLE
Modified GET /counselling-services/:id endpoint to use secondary ID

### DIFF
--- a/server/services/counselling-service.service.ts
+++ b/server/services/counselling-service.service.ts
@@ -97,7 +97,7 @@ async function getCounsellingServices(nameQuery: any,
 }
 
 async function getCounsellingService(id: string): Promise<ICounsellingService> {
-    return await CounsellingService.findById(id).lean();
+    return await CounsellingService.findOne({secondaryID: id}).lean();
 }
 
 async function createCounsellingService(inputService: ICounsellingService): Promise<ICounsellingService> {


### PR DESCRIPTION
## Description
#### Summary:
- Modified GET /counselling-services/:id endpoint to use secondary ID

#### Changes:
- Changed getCounsellingService in service/counselling-service.service.ts to query using secondaryID with findOne instead of using findID

#### How to test this PR:
- Try to access counselling services using /counsellingservices/<secondaryID> for any service to determine if the URL directs you correctly

  
  
