### PR TITLE
Fix issue with dotenv config not finding .env file

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2,10 +2,11 @@
 import express from 'express';
 import mongoose from 'mongoose';
 import cors from 'cors';
+import path from 'path';
 
 const envFile = process.env.NODE_ENV === 'test' ? 'test.env' : '.env';
 
-require('dotenv').config({ path: envFile });
+require('dotenv').config({ path: path.resolve(__dirname, envFile) });
 
 // Initialize the express engine
 const app: express.Application = express();


### PR DESCRIPTION
## Description
#### Summary:
For some reason, when running the server, the app doesn’t always find the `.env` file. It appears to be some kind of path issue where the app is looking in the wrong directory. However, we can't consistently reproduce this issue on different environments, so we'll just have to make sure it's working for everyone.

#### Changes:
- Changed the `path` for the `dotenv` config in the `index.ts` file so that it includes the current directory (wherever that may be)

#### How to test this PR:
- Make sure you have the `.env` file in your `server` directory. If you haven't done this yet, check out [this doc](https://docs.google.com/document/d/1eTo2T_JOeqNqoaO235cSUXTCX-9Mlwex6t9U8BatfaM/edit) and let me know if you need credentials
- Run `npm start` in the `server` directory, the server should start as normal (should be no errors in the terminal output)
  
## Checklist

- [x] I performed a self-review of my code
- [x] (Backend only) I ran all the tests using `npm test` and they were successful
- [x] (Backend only) I ran the linter using `npm run lint` and there were no errors
