### PR TITLE
Add specialty list endpoint and update counselling service specialties

### DIFF
--- a/documentation/counselling-services-api.md
+++ b/documentation/counselling-services-api.md
@@ -30,7 +30,7 @@ Query Params:
 | `serviceType` | `ServiceType array` | The type of service offered, one or more of: "Medical", "Counselling", "Crisis", "Wellness", "Workshop" |
 | `urgency` | `UrgencyLevel array` | The maximum level of urgency the service caters to, one or more of: "Immediate", "Same Day", "Same Week", "Same Month" |
 | `targetClients` | `string array` | The clients the service is targeted towards, e.g. "UBC students" or "Indigenous people, all ages" |
-| `specialty` | `string array` | The areas the service specializes in, e.g. "Trauma" or "Addiction" |
+| `specialty` | `string` | The areas the service specializes in, e.g. "Trauma" or "Addiction". The input must be an ID representing the specialty, as defined in `documentation/specialties-api.md` |
 | `keywordSearch` | `string array` | This is internal keywords that do not get displayed, meant to refine searches |
 | `delivery` | `DeliveryMethod array` | Format(s) in which the service is offered, one or more of: "In person", "Online", "Phone", "App", "Email" |
 | `description` | `string` | A description of the service |
@@ -62,11 +62,18 @@ Example response for GET http://localhost:4000/counselling-services?specialty=tr
             "website": "https://www.sfu.ca/students/health/resources/identity/Indigenous-Students.html",
             "keywordSearch": [],
             "specialty": [
-                "Stress",
-                "Anxiety",
-                "Depression",
-                "Grief",
-                "Trauma"
+                {
+                    "id": "STRESS_AXTY",
+                    "label": "Stress/Anxiety"
+                },
+                {
+                    "id": "DEPRESSION",
+                    "label": "Depression"
+                },
+                {
+                    "id": "TRAUMA",
+                    "label": "Trauma"
+                }
             ],
             "delivery": [
                 "In Person"
@@ -106,7 +113,7 @@ Example response for GET http://localhost:4000/counselling-services?specialty=tr
 |:-----------|:-------------|
 |GET http://localhost:4000/counselling-services?delivery=app | All services that offer delivery via app (including those that use additional delivery methods) |
 |GET http://localhost:4000/counselling-services?delivery=online&school=ubc | All services that are offered online AND have UBC as their associated school |
-|GET http://localhost:4000/counselling-services?specialty=anxiety&specialty=stress | All services that specialize in at least one of anxiety or stress |
+|GET http://localhost:4000/counselling-services?specialty=STRESS_AXTY&specialty=ADDICTION | All services that specialize in at least one of stress/anxiety OR addiction |
 
 
 ## Get a Counselling Service

--- a/documentation/counselling-services-api.md
+++ b/documentation/counselling-services-api.md
@@ -30,7 +30,7 @@ Query Params:
 | `serviceType` | `ServiceType array` | The type of service offered, one or more of: "Medical", "Counselling", "Crisis", "Wellness", "Workshop" |
 | `urgency` | `UrgencyLevel array` | The maximum level of urgency the service caters to, one or more of: "Immediate", "Same Day", "Same Week", "Same Month" |
 | `targetClients` | `string array` | The clients the service is targeted towards, e.g. "UBC students" or "Indigenous people, all ages" |
-| `specialty` | `string` | The areas the service specializes in, e.g. "Trauma" or "Addiction". The input must be an ID representing the specialty, as defined in `documentation/specialties-api.md` |
+| `specialty` | `string` | The areas the service specializes in, e.g. "Trauma" or "Addiction". The input must be an ID representing the specialty, as defined in [documentation/specialties-api.md](https://github.com/bring-it-up/bring-it-up/blob/8fec92c1e5baa0d7e439be4fd09377f1c0716752/documentation/specialties-api.md) |
 | `keywordSearch` | `string array` | This is internal keywords that do not get displayed, meant to refine searches |
 | `delivery` | `DeliveryMethod array` | Format(s) in which the service is offered, one or more of: "In person", "Online", "Phone", "App", "Email" |
 | `description` | `string` | A description of the service |

--- a/documentation/specialties-api.md
+++ b/documentation/specialties-api.md
@@ -1,0 +1,59 @@
+# Public API Methods (Specialties)
+
+These docs will only document the specialty endpoints meant to be used by the client (frontend).
+
+## Overview
+
+| Method     | Resource                    | Description                       |
+|:-----------|:----------------------------|:----------------------------------|
+| `GET` | [`/specialties`](#Get-Specialties) | returns the list of specialties as an object |
+
+## Get Specialties
+
+`GET` `/specialties`
+
+Returns an object where each property is the specialty's ID, and each value is an object containing attributes for the specialty. The full list of specialties can be found below.
+
+### Request
+
+Query Params: There are no query parameters for this request.
+
+
+### Response
+
+Example response for GET http://localhost:4000/specialties :
+
+    {
+        "STRESS_AXTY": {
+            "id": "STRESS_AXTY",
+            "label": "Stress/Anxiety"
+        },
+        "DEPRESSION": {
+            "id": "DEPRESSION",
+            "label": "Depression"
+        },
+        ... more
+    }
+
+
+## Full List of Specialties
+
+| id  | label         | 
+|:-----------|:-------------|
+| STRESS_AXTY | Stress/Anxiety |
+| DEPRESSION | Depression |
+| TRAUMA | Trauma |
+| ACADEMICS | Academics |
+| LONELINESS | Loneliness |
+| RELATIONSHIPS | Relationships |
+| CULTURAL_ADJST | Cultural Adjustment |
+| IDENTITY | Identity |
+| MTL_HEALTH_DSDR | Mental Health Disorder |
+| PHOBIA | Phobia |
+| EMOTIONAL_REG | Emotional Regulation |
+| PHYSICAL | Physical Well-being |
+| COPING_CHANGE | Coping with Change |
+| TIME_MGMT | Time Management |
+| CRISIS | Crisis |
+| ADDICTION | Addiction |
+| EATING_DSDR | Eating Disorder |

--- a/server/bring-it-up.postman_collection.json
+++ b/server/bring-it-up.postman_collection.json
@@ -181,7 +181,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"serviceName\": \"ISC Wellness Program\",\n    \"school\": \"SFU\",\n    \"organization\": \"Indigenous Student Centre (ISC)\",\n    \"serviceType\": [\n        \"Wellness\"\n    ],\n    \"urgency\": \"Same Month\",\n    \"targetClients\": [\n        \"Indigenous SFU students\"\n    ],\n    \"website\": \"https://www.sfu.ca/students/indigenous/isc-wellness.html\",\n    \"keywordSearch\": [],\n    \"specialty\": [\n        \"Mental wellness\",\n        \"Physical wellness\",\n        \"Social wellness\"\n    ],\n    \"delivery\": [\n        \"Online\"\n    ],\n    \"description\": \"The Wellness Program is a virtual community open to currently enrolled Indigenous students. Wherever you are, you can participate in a Run/Walk training program, learn about and share resources, engage with topics of mental, physical, and social wellness, and win prizes!\"\n}",
+							"raw": "{\n    \"serviceName\": \"ISC Wellness Program\",\n    \"school\": \"SFU\",\n    \"organization\": \"Indigenous Student Centre (ISC)\",\n    \"serviceType\": [\n        \"Wellness\"\n    ],\n    \"urgency\": \"Same Month\",\n    \"targetClients\": [\n        \"Indigenous SFU students\"\n    ],\n    \"isAllDay\": false,\n    \"website\": \"https://www.sfu.ca/students/indigenous/isc-wellness.html\",\n    \"keywordSearch\": [],\n    \"specialty\": [\n        \"STRESS_AXTY\",\n        \"PHYSICAL\",\n        \"IDENTITY\"\n    ],\n    \"delivery\": [\n        \"Online\"\n    ],\n    \"description\": \"The Wellness Program is a virtual community open to currently enrolled Indigenous students. Wherever you are, you can participate in a Run/Walk training program, learn about and share resources, engage with topics of mental, physical, and social wellness, and win prizes!\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -280,6 +280,29 @@
 							],
 							"path": [
 								"counselling-services"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "specialties",
+			"item": [
+				{
+					"name": "/specialties",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{local_url}}/specialties",
+							"protocol": "http",
+							"host": [
+								"{{local_url}}"
+							],
+							"path": [
+								"specialties"
 							]
 						}
 					},

--- a/server/controllers/counselling-service.controller.ts
+++ b/server/controllers/counselling-service.controller.ts
@@ -4,7 +4,7 @@ import { generateSecondaryId } from '../utils/id-generator.util';
 import { filterRequest } from "../middleware/utils.middleware";
 import {StatusCode} from "../utils/status-code.enum";
 import DataJson from '../data/counselling-services.json';
-import { generateSpecialtyMap } from '../utils/specialty-list';
+import { SPECIALTY_MAP } from '../utils/specialty-list';
 
 async function getCounsellingServices(req: Request, res: Response) {  
     try {
@@ -104,10 +104,9 @@ async function addCounsellingServicesJSON(req: Request, res: Response) {
 
 function getSpecialties(req: Request, res: Response) {
   try {
-    const specialtyMap = generateSpecialtyMap();
-    res.status(200).json(specialtyMap);
+    res.status(StatusCode.OK).json(SPECIALTY_MAP);
   } catch (e) {
-    res.status(500).json({ message: 'There was an error with generating the specialty list' });
+    res.status(StatusCode.INTERNAL_SERVER_ERROR).json({ message: 'There was an error with generating the specialty list' });
   }
 }
 

--- a/server/controllers/counselling-service.controller.ts
+++ b/server/controllers/counselling-service.controller.ts
@@ -4,6 +4,7 @@ import { generateSecondaryId } from '../utils/id-generator.util';
 import { filterRequest } from "../middleware/utils.middleware";
 import {StatusCode} from "../utils/status-code.enum";
 import DataJson from '../data/counselling-services.json';
+import { generateSpecialtyMap } from '../utils/specialty-list';
 
 async function getCounsellingServices(req: Request, res: Response) {  
     try {
@@ -101,7 +102,14 @@ async function addCounsellingServicesJSON(req: Request, res: Response) {
   }
 }
 
-
+function getSpecialties(req: Request, res: Response) {
+  try {
+    const specialtyMap = generateSpecialtyMap();
+    res.status(200).json(specialtyMap);
+  } catch (e) {
+    res.status(500).json({ message: 'There was an error with generating the specialty list' });
+  }
+}
 
 export default {
     getCounsellingServices,
@@ -110,5 +118,6 @@ export default {
     updateCounsellingService,
     deleteCounsellingService,
     deleteAllCounsellingServices,
-    addCounsellingServicesJSON
+    addCounsellingServicesJSON,
+    getSpecialties
 };

--- a/server/data/counselling-services.json
+++ b/server/data/counselling-services.json
@@ -1,7 +1,7 @@
 [
     {
         "serviceName": "Student Assistance Program (SAP)",
-        "school": "ubc",
+        "school": "ubcv",
         "organization": "Aspiria",
         "serviceType": [
             "Counselling"
@@ -13,16 +13,13 @@
         "website": "https://students.ubc.ca/health/ubc-student-assistance-program-sap",
         "keywordSearch":[],
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Depression",
-            "Addiction",
-            "Crisis",
-            "Grief",
-            "Trauma",
-            "Fitness",
-            "Nutrition",
-            "Sleep"
+            "STRESS_AXTY",
+            "DEPRESSION",
+            "ADDICTION",
+            "CRISIS",
+            "TRAUMA",
+            "PHYSICAL",
+            "EATING_DSDR"
         ],
         "delivery": [
             "Online",
@@ -57,7 +54,7 @@
     },
     {
         "serviceName": "Group Counselling Programs",
-        "school": "ubc",
+        "school": "ubcv",
         "organization": "UBC Counselling Services",
         "serviceType": [
             "Counselling"
@@ -69,9 +66,8 @@
         "website": "https://students.ubc.ca/health/counselling-services/group-counselling-programs",
         "keywordSearch":[],
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Academics"
+            "STRESS_AXTY",
+            "ACADEMICS"
         ],
         "delivery": [
             "Online"
@@ -93,11 +89,9 @@
         "website": "https://foundrybc.ca/virtual/",
         "keywordSearch":[],
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Depression",
-            "Grief",
-            "Trauma"
+            "STRESS_AXTY",
+            "DEPRESSION",
+            "TRAUMA"
         ],
         "delivery": [
             "Online",
@@ -150,13 +144,10 @@
             "Multiple language options"
         ],
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Depression",
-            "Crisis",
-            "Grief",
-            "Trauma",
-            "Multiple language options"
+            "STRESS_AXTY",
+            "DEPRESSION",
+            "CRISIS",
+            "TRAUMA"
         ],
         "delivery": [
             "Online",
@@ -209,11 +200,9 @@
             "Adapting to a new campus culture, learning style or city"
         ],
         "specialty": [
-            "Isolation",
-            "Loneliness",
-            "Depression",
-            "Academics",
-            "Multiple language options"
+            "LONELINESS",
+            "DEPRESSION",
+            "ACADEMICS"
         ],
         "delivery": [
             "Online",
@@ -273,10 +262,9 @@
             "Helping a friend in crisis"
         ],
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Homesickness",
-            "Cultural Adjustment"
+            "STRESS_AXTY",
+            "LONELINESS",
+            "CULTURAL_ADJST"
         ],
         "delivery": [
             "Online",
@@ -300,9 +288,7 @@
         "website": "https://www.sfu.ca/students/indigenous/isc-wellness.html",
         "keywordSearch":[],
         "specialty": [
-            "Mental wellness",
-            "Physical wellness",
-            "Social wellness"
+            "PHYSICAL"
         ],
         "delivery": [
             "Online"
@@ -323,11 +309,9 @@
         ],
         "website": "https://www.sfu.ca/students/health/resources/identity/Indigenous-Students.html",
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Depression",
-            "Grief",
-            "Trauma"
+            "STRESS_AXTY",
+            "DEPRESSION",
+            "TRAUMA"
         ],
         "keywordSearch":[],
         "delivery": [
@@ -354,10 +338,8 @@
             "Distress surrounding international conflicts"
         ],
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Depression",
-            "Distress surrounding international conflicts"
+            "STRESS_AXTY",
+            "DEPRESSION"
         ],
         "delivery": [
             "Online",
@@ -389,12 +371,11 @@
             "Academic pressures"
         ],
         "specialty": [
-            "Stress reduction",
-            "Anxiety",
-            "Depression",
-            "Relationships",
-            "Trauma",
-            "Academic success"
+            "STRESS_AXTY",
+            "DEPRESSION",
+            "RELATIONSHIPS",
+            "TRAUMA",
+            "ACADEMICS"
         ],
         "delivery": [
             "Online",
@@ -451,11 +432,9 @@
             "Strengthening relationships"
         ],
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Depression",
-            "Grief",
-            "Trauma"
+            "STRESS_AXTY",
+            "DEPRESSION",
+            "TRAUMA"
         ],
         "delivery": [
             "Phone"
@@ -488,7 +467,7 @@
     },
     {
         "serviceName": "UBC Psychology Clinic",
-        "school": "ubc",
+        "school": "ubcv",
         "organization": "UBC Psychology",
         "serviceType": [
             "Counselling"
@@ -510,9 +489,8 @@
             "Neuropsychological assessment"
         ],
         "specialty": [
-            "Stress",
-            "Anxiety",
-            "Depression"
+            "STRESS_AXTY",
+            "DEPRESSION"
         ],
         "isOfferedOnline": false,
         "delivery": [

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import mongoose from 'mongoose';
 import cors from 'cors';
 import path from 'path';
+import specialtiesRouter from './routes/specialties.api';
 
 const envFile = process.env.NODE_ENV === 'test' ? 'test.env' : '.env';
 
@@ -62,5 +63,7 @@ app.use('/counselling-services', counsellingServicesRouter);
 
 const schoolsRouter = require('./routes/school.api.ts');
 app.use('/schools', schoolsRouter);
+
+app.use(specialtiesRouter);
 
 export default app;

--- a/server/middleware/counselling-service.middleware.ts
+++ b/server/middleware/counselling-service.middleware.ts
@@ -4,6 +4,7 @@ import {UrgencyLevel} from "../models/urgency-level.enum";
 import {DeliveryMethod} from "../models/delivery-method.enum";
 import {BadRequestError} from "./bad-request-error";
 import {isValidHour} from "./hours-request-validator";
+import { isValidSpecialtyId } from "../utils/specialty-list";
 
 /*
     This file contains the logic for validating requests to
@@ -32,6 +33,11 @@ const isValidDelivery: CustomValidator = delivery => {
     } else {
         throw new BadRequestError("invalid value");
     }
+};
+
+const isValidSpecialty: CustomValidator = specialty => {
+    if (isValidSpecialtyId(specialty)) return true;
+    else throw new BadRequestError(`'${specialty}' is not a valid specialty`);
 };
 
 export const postRules = [
@@ -75,7 +81,7 @@ export const postRules = [
         .withMessage("specialty is not an array"),
     body('specialty.*')
         .exists({checkNull: true, checkFalsy:true})
-        .isString(),
+        .custom(isValidSpecialty),
     body('delivery')
         .exists({checkNull: true, checkFalsy:true})
         .isArray({min: 1})

--- a/server/models/counsellingService.model.ts
+++ b/server/models/counsellingService.model.ts
@@ -3,6 +3,7 @@ import { ServiceType } from './counselling-type.enum';
 import { DeliveryMethod } from './delivery-method.enum';
 import { UrgencyLevel } from './urgency-level.enum';
 import { Hours } from './hours.model';
+import { Specialty } from './specialty.model';
 
 // interface to reinforce types
 export interface ICounsellingService {
@@ -15,7 +16,7 @@ export interface ICounsellingService {
     targetClients: string[];
     website: string;
     keywordSearch: string[],
-    specialty: string[];
+    specialty: string[] | Specialty[]; // TODO: We should be using separate types for DB objects and response objects
     delivery: DeliveryMethod[];
     description: string;
     logo?: string;
@@ -64,7 +65,6 @@ const CounsellingServiceSchema = new mongoose.Schema<CounsellingServiceDoc>({
     },
     targetClients: {
         type: [String],
-        default: undefined,
         required: true
     },
     website: {
@@ -73,12 +73,10 @@ const CounsellingServiceSchema = new mongoose.Schema<CounsellingServiceDoc>({
     },
     keywordSearch: {
         type: [String],
-        default: undefined,
         required: false
     },
     specialty: {
         type: [String],
-        default: undefined,
         required: true
     },
     delivery: {

--- a/server/models/specialty.enum.ts
+++ b/server/models/specialty.enum.ts
@@ -1,0 +1,19 @@
+export enum SpecialtyEnum {
+    STRESS_AXTY = 'Stress/Anxiety',
+    DEPRESSION = 'Depression',
+    TRAUMA = 'Trauma',
+    ACADEMICS = 'Academics',
+    LONELINESS = 'Loneliness',
+    RELATIONSHIPS = 'Relationships',
+    CULTURAL_ADJST = 'Cultural Adjustment',
+    IDENTITY = 'Identity',
+    MTL_HEALTH_DSDR = 'Mental Health Disorder',
+    PHOBIA = 'Phobia',
+    EMOTIONAL_REG = 'Emotional Regulation',
+    PHYSICAL = 'Physical Well-being',
+    COPING_CHANGE = 'Coping with Change',
+    TIME_MGMT = 'Time Management',
+    CRISIS = 'Crisis',
+    ADDICTION = 'Addiction',
+    EATING_DSDR = 'Eating Disorder'
+}

--- a/server/models/specialty.model.ts
+++ b/server/models/specialty.model.ts
@@ -1,0 +1,6 @@
+export interface Specialty {
+    id: string;
+    label: string;
+}
+
+export type SpecialtyMap = { [id: string]: Specialty };

--- a/server/routes/specialties.api.ts
+++ b/server/routes/specialties.api.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import CounsellingServiceController from '../controllers/counselling-service.controller';
+
+const router = express.Router();
+
+router.get('/specialties', CounsellingServiceController.getSpecialties);
+
+export default router;

--- a/server/services/counselling-service.service.ts
+++ b/server/services/counselling-service.service.ts
@@ -57,8 +57,10 @@ async function getCounsellingService(id: string): Promise<ICounsellingService> {
     const services = await CounsellingService.aggregate(getAggregation(match));
     const service: ICounsellingService = services[0];
 
-    // Transform array of specialty IDs to specialty objects
-    service.specialty = getSpecialtyListFromIds(service.specialty as string[]);
+    if (service) {
+        // Transform array of specialty IDs to specialty objects
+        service.specialty = getSpecialtyListFromIds(service.specialty as string[]);
+    }
 
     return service;
 }

--- a/server/tests/integration/counselling-service.spec.ts
+++ b/server/tests/integration/counselling-service.spec.ts
@@ -154,8 +154,13 @@ function assertCounsellingService(service: any, serviceData: any, schoolData: an
     const keys = ['serviceName', 'organization', 'serviceType', 'urgency', 'targetClients',
         'website', 'specialty', 'delivery', 'serviceName', 'secondaryID'];
 
+
     for (const key of keys) {
-        service[key].should.be.eql(serviceData[key]);
+        if (key === 'specialty') {
+            checkSpecialtyField(service[key]);
+        } else {
+            service[key].should.be.eql(serviceData[key]);
+        }
     }
 
     service.should.have.property('school');
@@ -166,3 +171,13 @@ function assertCounsellingService(service: any, serviceData: any, schoolData: an
     service.should.not.have.property('school._id');
     service.should.not.have.property('school.__v');
 }
+
+const checkSpecialtyField = (specialtyField: any) => {
+    specialtyField.should.be.an('array');
+
+    for (const specialty of specialtyField) {
+        specialty.should.be.an('object');
+        specialty.should.have.property('id');
+        specialty.should.have.property('label');
+    }
+};

--- a/server/tests/integration/data/counselling-service-data.ts
+++ b/server/tests/integration/data/counselling-service-data.ts
@@ -6,7 +6,7 @@ export const service1Data = {
     urgency: "Immediate",
     targetClients: ["UBC students"],
     website: "https://students.ubc.ca/health/ubc-student-assistance-program-sap",
-    specialty: ["Stress", "Anxiety"],
+    specialty: ["STRESS_AXTY"],
     delivery: ["Online","Phone"],
     description: "Offered by Aspiria, the UBC Student Assistance Program (SAP) is a free, 24/7 wellness resource for students. Services include personal counselling, life coaching, group programs and more based on your needs.",
     secondaryID: "student-assistance-program-sap"
@@ -20,7 +20,7 @@ export const service2Data = {
     urgency: "Immediate",
     targetClients: ["SFU students","FIC students"],
     website: "https://www.sfu.ca/students/health/get-support/my-ssp.html",
-    specialty: ["Stress","Anxiety","Homesickness","Cultural Adjustment"],
+    specialty: ["STRESS_AXTY","LONELINESS","CULTURAL_ADJST"],
     isOfferedOnline: true,
     delivery: ["Online","Phone","App"],
     description: "My SSP (My Student Support Program) is an app dedicated to supporting SFU/FIC students through its 24/7 crisis line, short-term counselling appointments and relevant resources on a range of mental health topics.",
@@ -36,7 +36,7 @@ export const service3Data = {
     urgency: "Same Month",
     targetClients: ["Adults in Greater Vancouver"],
     website: "https://clinic.psych.ubc.ca/services/",
-    specialty: ["Stress", "Anxiety", "Depression"],
+    specialty: ["STRESS_AXTY", "DEPRESSION"],
     isOfferedOnline: false,
     delivery: ["In Person"],
     description: "The UBC Psychology Clinic offers comprehensive psychological services adults. Our clinical services are provided by graduate students from UBC’s doctoral programme in clinical psychology. Student clinicians are closely supervised by Registered Psychologists from our faculty and the community.Our Clinic is not able to provide psychiatric or emergency services or services where there is a risk of frequent or severe crisis or involvement with the law."

--- a/server/tests/integration/data/counselling-service-invalid-request-data.ts
+++ b/server/tests/integration/data/counselling-service-invalid-request-data.ts
@@ -9,7 +9,7 @@ export const missingServiceNameData = {
     urgency: "Immediate",
     targetClients: ["UBC students"],
     website: "https://students.ubc.ca/health/ubc-student-assistance-program-sap",
-    specialty: ["Stress", "Anxiety"],
+    specialty: ["STRESS_AXTY"],
     delivery: ["Online","Phone"],
     description: "Offered by Aspiria, the UBC Student Assistance Program (SAP) is a free, 24/7 wellness resource for students. Services include personal counselling, life coaching, group programs and more based on your needs."
 };
@@ -22,7 +22,7 @@ export const invalidServiceNameData = {
     urgency: "Immediate",
     targetClients: ["UBC students"],
     website: "https://students.ubc.ca/health/ubc-student-assistance-program-sap",
-    specialty: ["Stress", "Anxiety"],
+    specialty: ["STRESS_AXTY"],
     delivery: ["Online","Phone"],
     description: "Offered by Aspiria, the UBC Student Assistance Program (SAP) is a free, 24/7 wellness resource for students. Services include personal counselling, life coaching, group programs and more based on your needs."
 };
@@ -35,7 +35,7 @@ export const invalidServiceTypeData = {
     urgency: "Immediate",
     targetClients: ["SFU students","FIC students"],
     website: "https://www.sfu.ca/students/health/get-support/my-ssp.html",
-    specialty: ["Stress","Anxiety","Homesickness","Cultural Adjustment"],
+    specialty: ["STRESS_AXTY","LONELINESS","CULTURAL_ADJST"],
     isOfferedOnline: true,
     delivery: ["Online","Phone","App"],
     description: "My SSP (My Student Support Program) is an app dedicated to supporting SFU/FIC students through its 24/7 crisis line, short-term counselling appointments and relevant resources on a range of mental health topics."
@@ -49,7 +49,7 @@ export const invalidUrgencyData = {
     urgency: "Invalid",
     targetClients: ["SFU students","FIC students"],
     website: "https://www.sfu.ca/students/health/get-support/my-ssp.html",
-    specialty: ["Stress","Anxiety","Homesickness","Cultural Adjustment"],
+    specialty: ["STRESS_AXTY","LONELINESS","CULTURAL_ADJST"],
     isOfferedOnline: true,
     delivery: ["Online","Phone","App"],
     description: "My SSP (My Student Support Program) is an app dedicated to supporting SFU/FIC students through its 24/7 crisis line, short-term counselling appointments and relevant resources on a range of mental health topics."
@@ -63,7 +63,7 @@ export const invalidTargetClientsData = {
     urgency: "Immediate",
     targetClients: ["SFU students",1000],
     website: "https://www.sfu.ca/students/health/get-support/my-ssp.html",
-    specialty: ["Stress","Anxiety","Homesickness","Cultural Adjustment"],
+    specialty: ["STRESS_AXTY","LONELINESS","CULTURAL_ADJST"],
     isOfferedOnline: true,
     delivery: ["Online","Phone","App"],
     description: "My SSP (My Student Support Program) is an app dedicated to supporting SFU/FIC students through its 24/7 crisis line, short-term counselling appointments and relevant resources on a range of mental health topics."
@@ -77,7 +77,7 @@ export const nonArrayTargetClientsData = {
     urgency: "Immediate",
     targetClients: "SFU students",
     website: "https://www.sfu.ca/students/health/get-support/my-ssp.html",
-    specialty: ["Stress","Anxiety","Homesickness","Cultural Adjustment"],
+    specialty: ["STRESS_AXTY","LONELINESS","CULTURAL_ADJST"],
     isOfferedOnline: true,
     delivery: ["Online","Phone","App"],
     description: "My SSP (My Student Support Program) is an app dedicated to supporting SFU/FIC students through its 24/7 crisis line, short-term counselling appointments and relevant resources on a range of mental health topics."
@@ -91,7 +91,7 @@ export const invalidDeliveryData = {
     urgency: "Immediate",
     targetClients: ["SFU students","FIC students"],
     website: "https://www.sfu.ca/students/health/get-support/my-ssp.html",
-    specialty: ["Stress","Anxiety","Homesickness","Cultural Adjustment"],
+    specialty: ["STRESS_AXTY","LONELINESS","CULTURAL_ADJST"],
     isOfferedOnline: true,
     delivery: ["Online","Phone","Invalid"],
     description: "My SSP (My Student Support Program) is an app dedicated to supporting SFU/FIC students through its 24/7 crisis line, short-term counselling appointments and relevant resources on a range of mental health topics."
@@ -105,7 +105,7 @@ export const invalidSpecialtyData = {
     urgency: "Immediate",
     targetClients: ["SFU students","FIC students"],
     website: "https://www.sfu.ca/students/health/get-support/my-ssp.html",
-    specialty: ["Stress","Anxiety",true,"Cultural Adjustment"],
+    specialty: ["STRESS_AXTY",true,"CULTURAL_ADJST"],
     isOfferedOnline: true,
     delivery: ["Online","Phone","App"],
     description: "My SSP (My Student Support Program) is an app dedicated to supporting SFU/FIC students through its 24/7 crisis line, short-term counselling appointments and relevant resources on a range of mental health topics."

--- a/server/tests/integration/specialties.spec.ts
+++ b/server/tests/integration/specialties.spec.ts
@@ -1,0 +1,34 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../../index';
+import { SpecialtyEnum } from '../../models/specialty.enum';
+import { StatusCode } from '../../utils/status-code.enum';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const should = chai.should();
+
+chai.use(chaiHttp);
+
+describe('Counselling Service Specialties', () => {
+    
+    describe('GET /specialties', () => {
+        it('should get all specialties', async () => {
+            const response = await chai.request(server)
+                .get('/specialties');
+            response.should.have.status(StatusCode.OK);
+            response.body.should.be.an('object');
+
+            const specialtyKeys = Object.keys(SpecialtyEnum);
+            const specialtyLabels = Object.values(SpecialtyEnum);
+
+            for (const key in response.body) {
+                specialtyKeys.should.include(key);
+                const specialtyObj = response.body[key];
+                specialtyObj.should.be.an('object');
+                specialtyObj.should.have.property('id');
+                specialtyObj.should.have.property('label');
+                specialtyLabels.should.include(specialtyObj.label);
+            }
+        });
+    });
+});

--- a/server/utils/specialty-list.ts
+++ b/server/utils/specialty-list.ts
@@ -23,3 +23,5 @@ export const getSpecialtyListFromIds = (ids: string[]): Specialty[] => ids.map(g
 export const getSpecialtyIdsFromSpecialtyList = (specialties: Specialty[]): string[] => {
     return specialties.map(specialty => specialty.id);
 };
+
+export const isValidSpecialtyId = (id: string) => id in SPECIALTY_MAP;

--- a/server/utils/specialty-list.ts
+++ b/server/utils/specialty-list.ts
@@ -1,5 +1,5 @@
 import { SpecialtyEnum } from "../models/specialty.enum";
-import { SpecialtyMap } from "../models/specialty.model";
+import { Specialty, SpecialtyMap } from "../models/specialty.model";
 
 export const generateSpecialtyMap = (): SpecialtyMap => {
     const result: SpecialtyMap = {};
@@ -12,4 +12,14 @@ export const generateSpecialtyMap = (): SpecialtyMap => {
         };
     });
     return result;
+};
+
+export const SPECIALTY_MAP = generateSpecialtyMap();
+
+export const getSpecialtyFromId = (id: string): Specialty => SPECIALTY_MAP[id];
+
+export const getSpecialtyListFromIds = (ids: string[]): Specialty[] => ids.map(getSpecialtyFromId);
+
+export const getSpecialtyIdsFromSpecialtyList = (specialties: Specialty[]): string[] => {
+    return specialties.map(specialty => specialty.id);
 };

--- a/server/utils/specialty-list.ts
+++ b/server/utils/specialty-list.ts
@@ -1,0 +1,15 @@
+import { SpecialtyEnum } from "../models/specialty.enum";
+import { SpecialtyMap } from "../models/specialty.model";
+
+export const generateSpecialtyMap = (): SpecialtyMap => {
+    const result: SpecialtyMap = {};
+    const specialtyEnumKeys = Object.keys(SpecialtyEnum);
+    const specialtyEnumValues = Object.values(SpecialtyEnum);
+    specialtyEnumKeys.forEach((id, index) => {
+        result[id] = {
+            id,
+            label: specialtyEnumValues[index],
+        };
+    });
+    return result;
+};


### PR DESCRIPTION
## Description
#### Summary:
- Added the [list of specialties](https://docs.google.com/spreadsheets/d/1mpVme2RHvipDOFzsbs_qd0YsZTDnONfN4YXVWn8G4Gw/edit?usp=sharing) to the backend so that it can be queried, and updated existing logic and data to use these specialties

#### Changes:
- Added a `GET /specialties` endpoint to retrieve the list of specialties. Each specialty has an ID and a label (so that we can change the label later if necessary)
- Modified the `GET /counselling-services` and `GET /counselling-services/:id` endpoints to return the ID and label for each specialty in each service. Only the specialty IDs are stored in the DB for each service.
- Updated the input validation logic for the specialty field
- Updated existing tests for the specialty field
- Added a test for the `GET /specialties` endpoint
- Updated `counselling-services.json` to use the new specialty IDs
- Updated the Postman collection
- Updated API docs

#### How to test this PR:
- Run the tests
- Manual testing:
  - Update your DB by calling the internal `PUT /counselling-services` request
  - Call `GET /counselling-services` or `GET /counselling-services/:id`, you should see the new structure for the specialty field
  - Call the new endpoint `GET /specialties` to see the whole list
- Look over the updated docs ([here](https://github.com/bring-it-up/bring-it-up/blob/be-54-add-specialty-list/documentation/counselling-services-api.md) and [here](https://github.com/bring-it-up/bring-it-up/blob/be-54-add-specialty-list/documentation/specialties-api.md)) and see if the info makes sense


#### Screenshots:
 
Getting the counselling services should look something like this:
<img width="919" alt="Screenshot 2022-12-07 at 6 27 46 PM" src="https://user-images.githubusercontent.com/57027339/206341467-fde97afd-e0e5-48bc-a84a-8a70d833dc79.png">

## Checklist

- [x] I performed a self-review of my code
- [x] (Backend only) I ran all the tests using `npm test` and they were successful
- [x] (Backend only) I ran the linter using `npm run lint` and there were no errors
