### PR TITLE
Add input validation to internal PUT request

### DIFF
--- a/server/controllers/counselling-service.controller.ts
+++ b/server/controllers/counselling-service.controller.ts
@@ -3,7 +3,6 @@ import CSService from '../services/counselling-service.service';
 import { generateSecondaryId } from '../utils/id-generator.util';
 import { filterRequest } from "../middleware/utils.middleware";
 import {StatusCode} from "../utils/status-code.enum";
-import DataJson from '../data/counselling-services.json';
 import { SPECIALTY_MAP } from '../utils/specialty-list';
 
 async function getCounsellingServices(req: Request, res: Response) {  
@@ -86,9 +85,9 @@ async function addCounsellingServicesJSON(req: Request, res: Response) {
     const final_obj:any = {final_push: []};  
     let vis_DataJson:any = {};
 
-    for (let i = 0; i < DataJson.length; ++i) {
-      vis_DataJson = DataJson[i];
-      vis_DataJson.secondaryID = generateSecondaryId(DataJson[i]['serviceName']);
+    for (let i = 0; i < req.body.length; ++i) {
+      vis_DataJson = req.body[i];
+      vis_DataJson.secondaryID = generateSecondaryId(req.body[i]['serviceName']);
       vis_DataJson.__v = 0;
       final_obj.final_push.push(vis_DataJson);
     }

--- a/server/middleware/counselling-service.middleware.ts
+++ b/server/middleware/counselling-service.middleware.ts
@@ -107,6 +107,73 @@ export const postRules = [
         .isBoolean(),
 ];
 
+export const postJSONRules = [
+    body('*.serviceName')
+        .exists({checkNull: true, checkFalsy:true})
+        .isString(),
+    body('*.location')
+        .optional()
+        .exists({checkNull: true, checkFalsy:true})
+        .isString(),
+    body('*.school')
+        .optional()
+        .exists({checkNull: true, checkFalsy:true})
+        .isString(),
+    body('*.organization')
+        .exists({checkNull: true, checkFalsy:true})
+        .isString(),
+    body('*.serviceType')
+        .exists({checkNull: true, checkFalsy:true})
+        .isArray({min: 1})
+        .withMessage("serviceType is not an array"),
+    body('*.serviceType.*')
+        .exists({checkNull: true, checkFalsy:true})
+        .custom(isValidServiceType),
+    body('*.urgency')
+        .exists({checkNull: true, checkFalsy:true})
+        .custom(isValidUrgency),
+    body('*.targetClients')
+        .exists({checkNull: true, checkFalsy:true})
+        .isArray({min: 1}),
+    body('*.targetClients.*')
+        .exists({checkNull: true, checkFalsy:true})
+        .isString()
+        .withMessage("targetClients is not an array"),
+    body('*.website')
+        .exists({checkNull: true, checkFalsy:true})
+        .isString(),
+    body('*.specialty')
+        .exists({checkNull: true, checkFalsy:true})
+        .isArray({min: 1})
+        .withMessage("specialty is not an array"),
+    body('*.specialty.*')
+        .exists({checkNull: true, checkFalsy:true})
+        .custom(isValidSpecialty),
+    body('*.delivery')
+        .exists({checkNull: true, checkFalsy:true})
+        .isArray({min: 1})
+        .withMessage("delivery is not an array"),
+    body('*.delivery.*')
+        .exists({checkNull: true, checkFalsy:true})
+        .custom(isValidDelivery),
+    body('*.description')
+        .exists({checkNull: true, checkFalsy:true})
+        .isString(),
+    body('*.logo')
+        .optional()
+        .exists({checkNull: true, checkFalsy:true})
+        .isString(),
+    body('*.hours')
+        .optional()
+        .exists({checkNull: true, checkFalsy: true})
+        .custom(isValidHour)
+        .withMessage("invalid hour data"),
+    body('*.isFree')
+        .optional()
+        .exists({checkNull: true})
+        .isBoolean(),
+];
+
 export const patchRules = [
     body('serviceName')
         .optional()

--- a/server/middleware/counselling-service.middleware.ts
+++ b/server/middleware/counselling-service.middleware.ts
@@ -107,7 +107,7 @@ export const postRules = [
         .isBoolean(),
 ];
 
-export const postJSONRules = [
+export const putRules = [
     body('*.serviceName')
         .exists({checkNull: true, checkFalsy:true})
         .isString(),

--- a/server/routes/counsellingService.api.ts
+++ b/server/routes/counsellingService.api.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import CounsellingServiceController from '../controllers/counselling-service.controller';
-import {patchRules, postRules} from "../middleware/counselling-service.middleware";
+import {patchRules, postJSONRules, postRules} from "../middleware/counselling-service.middleware";
 import {validateRequest} from "../middleware/utils.middleware";
 
 const router = express.Router();
@@ -24,7 +24,7 @@ router.delete('/:id', CounsellingServiceController.deleteCounsellingService);
 router.delete('/', CounsellingServiceController.deleteAllCounsellingServices);
 
 // add json to database
-router.put('/', CounsellingServiceController.addCounsellingServicesJSON);
+router.put('/', postJSONRules, validateRequest, CounsellingServiceController.addCounsellingServicesJSON);
 
 
 module.exports = router;

--- a/server/routes/counsellingService.api.ts
+++ b/server/routes/counsellingService.api.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import CounsellingServiceController from '../controllers/counselling-service.controller';
-import {patchRules, postJSONRules, postRules} from "../middleware/counselling-service.middleware";
+import {patchRules, postRules, putRules} from "../middleware/counselling-service.middleware";
 import {validateRequest} from "../middleware/utils.middleware";
 
 const router = express.Router();
@@ -24,7 +24,7 @@ router.delete('/:id', CounsellingServiceController.deleteCounsellingService);
 router.delete('/', CounsellingServiceController.deleteAllCounsellingServices);
 
 // add json to database
-router.put('/', postJSONRules, validateRequest, CounsellingServiceController.addCounsellingServicesJSON);
+router.put('/', putRules, validateRequest, CounsellingServiceController.addCounsellingServicesJSON);
 
 
 module.exports = router;


### PR DESCRIPTION
## Description
#### Summary:
Add validation logic in the PUT request for populating a DB with the services in `counselling-services.json`

#### Changes:
- Adds validation rules (`postJSONRules`) in `counselling-service.middleware.ts` (basically the same as `postRules` just with wildcard added so it works on an array)
- Adds the validation rules to the PUT route in `counsellingService.api.ts`
- Fix `addCounsellingServicesJSON` in `counselling-service.controller.ts`, now takes the data from the request body instead of directly from `counselling-services.json` because validation is performed on the body.

#### How to test this PR:
- Change/remove one of the required fields of one of the services in `counselling-service.json` (e.g. remove `organization`) so that the data is invalid
- On a test database (e.g. `test_db`) submit a PUT request, you should get a 400 response with a message like `CounsellingService validation failed: organization: Path organization is required.`
  
## Checklist

- [x] I performed a self-review of my code
- [x] (Backend only) I ran all the tests using `npm test` and they were successful
- [x] (Backend only) I ran the linter using `npm run lint` and there were no errors
