### PR TITLE
Add base url env variable to frontend

### DIFF
--- a/client/env.sample
+++ b/client/env.sample
@@ -1,0 +1,2 @@
+# Replace with the remote server URL
+REACT_APP_BASE_URL=http://localhost:4000

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -3,6 +3,7 @@ import FirstDropdown from './FirstDropdown';
 import ServiceCard from './ServiceCard';
 import Service from '../Service';
 import SearchBar from './SearchBar';
+import { BASE_URL } from '../constants';
 
 const tags: string[] = ['a', 'b', 'c'];
 const arr: string[] = ['a', 'b', 'c'];
@@ -28,7 +29,7 @@ const Home = (): ReactElement => {
 	let searchStr = '';
 
 	useEffect(() => {
-		fetch('http://localhost:4000/counselling-services')
+		fetch(`${BASE_URL}/counselling-services`)
 			.then(res => res.json())
 			.then(parsedData => {
 				setServices(parsedData);
@@ -44,7 +45,7 @@ const Home = (): ReactElement => {
 		const controller = new AbortController();
 		const signal = controller.signal;
 
-		fetch(`http://localhost:4000/counselling-services?searchString=${searchString}`, { signal: signal }) // searchString=${searchStr}
+		fetch(`${BASE_URL}/counselling-services?searchString=${searchString}`, { signal: signal }) // searchString=${searchStr}
 			.then(res => res.json())
 			.then(parsedData => {
 				setServices(parsedData);

--- a/client/src/components/ServiceHoursCard.tsx
+++ b/client/src/components/ServiceHoursCard.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography';
 import { ReactElement, useEffect, useState } from 'react';
 import { Grid } from '@mui/material';
 import vector from '../images/vector.png';
+import { BASE_URL } from '../constants';
 
 export default function ServiceHoursCard({ parentToChild }: {parentToChild: string}): ReactElement {
 	const id = parentToChild.replace(/\W+/g, '-').replace(/-$/, '').toLowerCase();
@@ -12,7 +13,7 @@ export default function ServiceHoursCard({ parentToChild }: {parentToChild: stri
 	const [hours, setHours] = useState<any[]>([]);
 
 	useEffect(() => {
-		fetch(`http://localhost:4000/counselling-services/${id}`)
+		fetch(`${BASE_URL}/counselling-services/${id}`)
 			.then(res => res.json())
 			.then(function(myJson) {
 				setHours(myJson.hours);

--- a/client/src/components/Services.tsx
+++ b/client/src/components/Services.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useState, useEffect } from 'react';
 import { Link, generatePath } from 'react-router-dom';
+import { BASE_URL } from '../constants';
 
 
 function GetData(): string[] {
@@ -8,7 +9,7 @@ function GetData(): string[] {
   
 	// this returns array of all service objects
 	useEffect(() => {
-		fetch('http://localhost:4000/counselling-services')
+		fetch(`${BASE_URL}/counselling-services`)
 			.then(res => res.json())
 			.then(parsedData => setData(parsedData))
 			.catch((e) => console.log(e));

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.REACT_APP_BASE_URL;


### PR DESCRIPTION
## Description
#### Summary:
- Add BASE_URL environment variable to the frontend for deployment

#### Changes:
- Adds env.sample file to client directory with a sample of the REACT_APP_BASE_URL env variable
- Replaces all hardcoded localhost:4000 urls with BASE_URL

#### How to test this PR:
- Run `npm run start` in the client directory and check that all the data is being fetched correctly
  
## Checklist

- [X] I performed a self-review of my code
