### PR TITLE
[FE-#30, FE-#33] Full services page

### DIFF
--- a/client/src/components/BasicServiceDetails.tsx
+++ b/client/src/components/BasicServiceDetails.tsx
@@ -1,0 +1,42 @@
+import { Card, Typography, Box } from '@mui/material';
+import { ReactElement } from 'react';
+
+type ServiceDetailsProps = {
+    school?: string,
+    provider: string,
+    description: string,
+};
+
+type PropertyDetailsProps = {
+    propertyName: string,
+    value: string,
+};
+
+function PropertyDetails({ propertyName, value }: PropertyDetailsProps): ReactElement {
+    return (
+        <Box sx={{ margin: '20px 0px' }}>
+            <Typography sx={{ fontSize: '14px', fontWeight: '500' }}>{`${propertyName}: `}</Typography>
+            <Typography sx={{ fontSize: '14px', fontWeight: '700' }}>{value}</Typography>
+        </Box>
+    );
+}
+
+function ServiceDescription({ details }: { details: string }): ReactElement {
+    return (
+        <Card variant="outlined" sx={{ maxWidth: 350, background:'#FFFBFE', borderRadius:'28px' }}>
+            <Typography sx={{ margin: '24px', fontSize: '14px' }}>{details}</Typography>
+        </Card>
+    );
+}
+
+function BasicServiceDetails({ school, provider, description }: ServiceDetailsProps): ReactElement {
+    return (
+    <div>
+        {school && <PropertyDetails propertyName={'School'} value={school}/>}
+        <PropertyDetails propertyName={'Service Provider'} value={provider} />
+        <ServiceDescription details={description} />
+    </div>
+    );
+}
+
+export default BasicServiceDetails;

--- a/client/src/components/DeliveryMethods.tsx
+++ b/client/src/components/DeliveryMethods.tsx
@@ -1,0 +1,30 @@
+import { ReactElement } from 'react';
+import { CustomizedChip } from '../utils/customized.components';
+import { Box } from '@mui/system';
+import Typography from '@mui/material/Typography';
+import { DeliveryMethod } from '../types/delivery-method.enum';
+import { Apps, Email, Message, Person, Phone } from '@mui/icons-material';
+import { Icon } from '@mui/material';
+
+type DeliveryMethodsProps = {
+    deliveryMethods: DeliveryMethod[];
+};
+
+const ICON_MAP = new Map([
+    [DeliveryMethod.IN_PERSON, <Person style={{ color: 'var(--theme-purple)' }} />],
+    [DeliveryMethod.PHONE, <Phone style={{ color: 'var(--theme-purple)' }} />],
+    [DeliveryMethod.ONLINE, <Message style={{ color: 'var(--theme-purple)' }} />],
+    [DeliveryMethod.APP, <Apps style={{ color: 'var(--theme-purple)' }} />],
+    [DeliveryMethod.EMAIL, <Email style={{ color: 'var(--theme-purple)' }} />]
+]);
+
+function DeliveryMethods({ deliveryMethods }: DeliveryMethodsProps): ReactElement {
+    return (
+    <Box sx={{ maxWidth:'350px' }}>
+		<Typography sx={{ font: 'bold 16px/32px Roboto' }}>Delivery Methods</Typography>
+        {deliveryMethods.map(x => {return <CustomizedChip key={x} label={x} icon={ICON_MAP.get(x)} />;})}
+	</Box>
+    );
+}
+
+export default DeliveryMethods;

--- a/client/src/components/FullServicePage.tsx
+++ b/client/src/components/FullServicePage.tsx
@@ -11,6 +11,8 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import Specialties from './Specialties';
 import { getCounsellingServiceById } from '../api/counselling-service/counselling-service.api';
 import { CounsellingService } from '../types/counselling-service.types';
+import BasicServiceDetails from './BasicServiceDetails';
+import DeliveryMethods from './DeliveryMethods';
 
 const CustomizedTab = styled(Tab)({
 	padding: '0 100px',
@@ -75,12 +77,18 @@ function FullServicePage(): ReactElement {
 			</Tabs>
 		</Box>
 		<TabPanel value={value} index={0}>
-			<div>
-				<ServiceHoursCard hours={service?.hours} />
+			{service && <div className="servicePageContainer">
+			<div className="detailsContainer">
+				<BasicServiceDetails school={service?.school?.name} provider={service.organization} description={service.description}/>
+				<DeliveryMethods deliveryMethods={service.delivery}/>
 				{service?.specialty && (
 					<Specialties specialties={service.specialty} />
 				)}
 			</div>
+			<div>
+				<ServiceHoursCard hours={service?.hours} />
+			</div>
+			</div>}
 		</TabPanel>
 		<TabPanel value={value} index={1}>Reviews</TabPanel>
 	</div>

--- a/client/src/components/FullServicePage.tsx
+++ b/client/src/components/FullServicePage.tsx
@@ -78,16 +78,16 @@ function FullServicePage(): ReactElement {
 		</Box>
 		<TabPanel value={value} index={0}>
 			{service && <div className="servicePageContainer">
-			<div className="detailsContainer">
-				<BasicServiceDetails school={service?.school?.name} provider={service.organization} description={service.description}/>
-				<DeliveryMethods deliveryMethods={service.delivery}/>
-				{service?.specialty && (
-					<Specialties specialties={service.specialty} />
-				)}
-			</div>
-			<div>
-				<ServiceHoursCard hours={service?.hours} />
-			</div>
+				<div className="detailsContainer">
+					<BasicServiceDetails school={service?.school?.name} provider={service.organization} description={service.description}/>
+					<DeliveryMethods deliveryMethods={service.delivery}/>
+					{service.specialty && (
+						<Specialties specialties={service.specialty} />
+					)}
+				</div>
+				<div>
+					<ServiceHoursCard hours={service.hours} />
+				</div>
 			</div>}
 		</TabPanel>
 		<TabPanel value={value} index={1}>Reviews</TabPanel>

--- a/client/src/components/ServiceHoursCard.tsx
+++ b/client/src/components/ServiceHoursCard.tsx
@@ -31,12 +31,13 @@ export default function ServiceHoursCard({ hours }: Props): ReactElement {
 }
 
 function NoHoursAvailable() {
-	return <h3>Hours not available!</h3>;
+	return <></>;
 }
+
 function CurrentlyOpenCard(props: any) {
 	const days = Object.keys(props.hours);
 	return (
-		<Card variant="outlined" sx={{ maxWidth: 350, background:'#FFFBFE', borderRadius:'28px', height:'276px' }}>
+		<Card variant="outlined" sx={{ width: 350, background:'#FFFBFE', borderRadius:'28px', height:'276px' }}>
 			<CardContent>
 				<Grid container>
 					<Grid item xs ={3.5}>
@@ -60,7 +61,7 @@ function CurrentlyOpenCard(props: any) {
 function ClosedCard(props: any) {
 	const days = Object.keys(props.hours);
 	return (
-		<Card variant="outlined" sx={{ maxWidth: 350, background:'#FFFBFE', borderRadius:'28px', height:'276px' }}>
+		<Card variant="outlined" sx={{ width: 350, background:'#FFFBFE', borderRadius:'28px', height:'276px' }}>
 			<CardContent>
 				<Grid container>
 					<Grid item xs ={3.5}>

--- a/client/src/components/Specialties.tsx
+++ b/client/src/components/Specialties.tsx
@@ -1,19 +1,9 @@
-import Chip from '@mui/material/Chip';
-import { Box, styled } from '@mui/system';
+import { Box } from '@mui/system';
 import Typography from '@mui/material/Typography';
 import { ReactElement } from 'react';
 import { Specialty } from '../types/specialty.type';
+import { CustomizedChip } from '../utils/customized.components';
 
-const CustomizedChip = styled(Chip) ({
-    background: 'linear-gradient(0, rgba(103, 80, 164, 0.05), rgba(103, 80, 164, 0.05))',
-    boxShadow: '0px 1px 3px 1px rgba(0, 0, 0, 0.15)',
-    borderRadius: '8px',
-    margin: '7px',
-    '& .MuiChip-label': {
-        color: '#1c1b1f',
-        font:'500 14px/20px Roboto',
-     } 
-}) as typeof Chip;
 
 type Props = {
     specialties: Specialty[];
@@ -23,7 +13,7 @@ function Specialties({ specialties }: Props): ReactElement {
     return (
 	<Box sx={{ maxWidth:'350px' }}>
 		<Typography sx={{ font: 'bold 16px/32px Roboto' }}>Specialities</Typography>
-		{specialties.map(x => {return <CustomizedChip key={x.label} label={x.label} />;})}
+		{specialties.map(x => {return <CustomizedChip key={x.id} label={x.label} />;})}
 	</Box>
     );
     

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -34,10 +34,6 @@ code {
   gap: 20px;
 }
 
-.MuiChip-icon {
-  color: 'red' !important;
-}
-
 .serviceCard {
   background-color: var(--backgroundPurple);
   height: 159px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -22,6 +22,22 @@ code {
     monospace;
 }
 
+.servicePageContainer {
+  display: flex;
+  gap: 50px;
+  margin-left: 10%;
+}
+
+.detailsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.MuiChip-icon {
+  color: 'red' !important;
+}
+
 .serviceCard {
   background-color: var(--backgroundPurple);
   height: 159px;

--- a/client/src/utils/customized.components.ts
+++ b/client/src/utils/customized.components.ts
@@ -1,0 +1,13 @@
+import Chip from '@mui/material/Chip';
+import { styled } from '@mui/system';
+
+export const CustomizedChip = styled(Chip) ({
+    background: 'linear-gradient(0, rgba(103, 80, 164, 0.05), rgba(103, 80, 164, 0.05))',
+    boxShadow: '0px 1px 3px 1px rgba(0, 0, 0, 0.15)',
+    borderRadius: '8px',
+    margin: '7px',
+    '& .MuiChip-label': {
+        color: '#1c1b1f',
+        font:'500 14px/20px Roboto',
+     } 
+}) as typeof Chip;


### PR DESCRIPTION
## Description
#### Summary:
Implements the service school, provider, description and delivery methods components for the full service page.

#### Changes:
- Adds BasicServiceDetails.tsx that renders the school, provider and description
- Adds DeliveryMethods.tsx that renders the chips with appropriate icons
- Includes some styling in index.css to adjust page layout

#### How to test this PR:
1. Select a service from the home page
2. School, provider, description and delivery methods should be visible

## Screenshots:
<img width="1440" alt="Screen Shot 2023-05-20 at 2 21 27 AM" src="https://github.com/bring-it-up/bring-it-up/assets/98232527/dc186e96-edba-4203-906f-48196921710a">
<img width="1440" alt="Screen Shot 2023-05-20 at 2 23 50 AM" src="https://github.com/bring-it-up/bring-it-up/assets/98232527/c4f56a64-75b4-49bd-a6f0-7d986385ea13">
  
## Checklist
- [x] I performed a self-review of my code
