### PR TITLE
[FE#31] Hide placeholder components for phase 1

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,16 @@ import Home from './components/Home';
 import { ReactElement } from 'react';
 import FullServicePage from './components/FullServicePage';
 
+// unused app routes for phase 1
+const AppRoutes = (): ReactElement => {
+	return (
+		<>
+		<Route exact path='/about' component={About} />
+		<Route exact path='/services' component={Services} />
+		</>
+	);
+};
+
 function App(): ReactElement {
 	return (
 		<div>
@@ -14,8 +24,6 @@ function App(): ReactElement {
 				<Navigation />
 				<Switch>
 					<Route exact path='/' component={Home} />
-					<Route exact path='/about' component={About} />
-					<Route exact path='/services' component={Services} />
 					<Route path='/services/:ServiceID' component={FullServicePage} />
 				</Switch>
 			</Router>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,7 +7,7 @@ import Home from './components/Home';
 import { ReactElement } from 'react';
 import FullServicePage from './components/FullServicePage';
 
-// unused app routes for phase 1
+// TODO: unimplemented app routes for phase 1
 const AppRoutes = (): ReactElement => {
 	return (
 		<>

--- a/client/src/components/FullServicePage.tsx
+++ b/client/src/components/FullServicePage.tsx
@@ -11,6 +11,9 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import Specialties from './Specialties';
 import { getCounsellingServiceById } from '../api/counselling-service/counselling-service.api';
 import { CounsellingService } from '../types/counselling-service.types';
+import { useHistory } from 'react-router-dom';
+
+const disableReviewsTab = true;
 
 const CustomizedTab = styled(Tab)({
 	padding: '0 100px',
@@ -48,7 +51,7 @@ function TabPanel(props: TabPanelProps) {
         )}
 	</div>
     );
-  }
+}
 
 function FullServicePage(): ReactElement {
     const params = useParams<SERVICE>();
@@ -66,12 +69,18 @@ function FullServicePage(): ReactElement {
 		setValue(newValue);
 	};
 
+	const history = useHistory();
+
+	const handleClick = () => {
+		history.push(`/`);
+	};
+
     return (
 	<div>
 		<Box>
 			<Tabs TabIndicatorProps={{ style: { width: '0px' } }} value={value} onChange={handleChange}>
-				<CustomizedTab sx={{ left: '5%', width:'max-content' }} icon={<ArrowBackIcon sx={{ position: 'relative', right:'90px' }}/>} iconPosition = "start" label={service?.serviceName} />
-				<CustomizedTab sx={{ left: '80%', position: 'absolute' }} icon={<ArrowForwardIcon sx={{ position: 'relative', right:'50px' }}/>} iconPosition = "start" label="Reviews"/>
+				<CustomizedTab onClick={handleClick} sx={{ left: '5%', width:'max-content' }} icon={<ArrowBackIcon sx={{ position: 'relative', right:'90px' }}/>} iconPosition = "start" label={service?.serviceName} />
+				{!disableReviewsTab && <CustomizedTab sx={{ left: '80%', position: 'absolute' }} icon={<ArrowForwardIcon sx={{ position: 'relative', right:'50px' }}/>} iconPosition = "start" label="Reviews"/>}
 			</Tabs>
 		</Box>
 		<TabPanel value={value} index={0}>
@@ -82,7 +91,7 @@ function FullServicePage(): ReactElement {
 				)}
 			</div>
 		</TabPanel>
-		<TabPanel value={value} index={1}>Reviews</TabPanel>
+		{!disableReviewsTab && <TabPanel value={value} index={1}>Reviews</TabPanel>}
 	</div>
     );
 }

--- a/client/src/components/FullServicePage.tsx
+++ b/client/src/components/FullServicePage.tsx
@@ -15,6 +15,7 @@ import { useHistory } from 'react-router-dom';
 import BasicServiceDetails from './BasicServiceDetails';
 import DeliveryMethods from './DeliveryMethods';
 
+// TODO: disabled reviews tab for phase 1
 const disableReviewsTab = true;
 
 const CustomizedTab = styled(Tab)({

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { styled } from '@mui/system';
 import { ReactElement } from 'react';
 
-const CustomTitleButton = styled(Button)({
+const CustomizedHeading = styled(Typography)({
 	position: 'absolute',
 	left: '3%',
 	top: '25%',
@@ -13,11 +13,7 @@ const CustomTitleButton = styled(Button)({
 	fontWeight: '700',
 	fontStyle: 'normal',
 	lineHeight: '49px',
-	textTransform: 'capitalize',
-	'&:hover': {
-		color: '#151611',
-	},
-}) as typeof Button;
+}) as typeof Typography;
 
 const CustomizedButton = styled(Button)({
 	position: 'absolute',
@@ -67,7 +63,7 @@ const Navigation = (): ReactElement => {
 	return (
 		<AppBar position="static" elevation={0}>
 			<Toolbar disableGutters sx={{ background: 'white', height: '105px' }}>
-				<CustomTitleButton component={Link} to={'/'} >Bring It Up</ CustomTitleButton>
+				<CustomizedHeading variant="h1">Bring It Up</CustomizedHeading>
 			</Toolbar>
 		</AppBar>
 	);

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { styled } from '@mui/system';
 import { ReactElement } from 'react';
 
-const CustomizedHeading = styled(Typography)({
+const CustomTitleButton = styled(Button)({
 	position: 'absolute',
 	left: '3%',
 	top: '25%',
@@ -13,7 +13,11 @@ const CustomizedHeading = styled(Typography)({
 	fontWeight: '700',
 	fontStyle: 'normal',
 	lineHeight: '49px',
-}) as typeof Typography;
+	textTransform: 'capitalize',
+	'&:hover': {
+		color: '#151611',
+	},
+}) as typeof Button;
 
 const CustomizedButton = styled(Button)({
 	position: 'absolute',
@@ -30,32 +34,40 @@ const CustomizedButton = styled(Button)({
 	},
 }) as typeof Button;
 
+// hidden navbar items for phase 1
+const NavbarItems = (): ReactElement => {
+	return (
+	<>
+		<CustomizedButton component={Link} to={'/'} sx={{ left: '20%' }}>
+		Home
+	</CustomizedButton>
+	<CustomizedButton
+		component={Link}
+		to={'/services'}
+		sx={{ left: '30%' }}
+	>
+		Services
+	</CustomizedButton>
+	<CustomizedButton component={Link} to={'/about'} sx={{ left: '42%' }}>
+		About
+	</CustomizedButton>
+	<CustomizedButton
+		sx={{
+			textDecoration: 'underline',
+			right: '3%',
+		}}
+	>
+		Sign in
+	</CustomizedButton>
+	</>
+	);
+};
+
 const Navigation = (): ReactElement => {
 	return (
 		<AppBar position="static" elevation={0}>
 			<Toolbar disableGutters sx={{ background: 'white', height: '105px' }}>
-				<CustomizedHeading variant="h1">Bring It Up</CustomizedHeading>
-				<CustomizedButton component={Link} to={'/'} sx={{ left: '20%' }}>
-					Home
-				</CustomizedButton>
-				<CustomizedButton
-					component={Link}
-					to={'/services'}
-					sx={{ left: '30%' }}
-				>
-					Services
-				</CustomizedButton>
-				<CustomizedButton component={Link} to={'/about'} sx={{ left: '42%' }}>
-					About
-				</CustomizedButton>
-				<CustomizedButton
-					sx={{
-						textDecoration: 'underline',
-						right: '3%',
-					}}
-				>
-					Sign in
-				</CustomizedButton>
+				<CustomTitleButton component={Link} to={'/'} >Bring It Up</ CustomTitleButton>
 			</Toolbar>
 		</AppBar>
 	);

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -30,7 +30,7 @@ const CustomizedButton = styled(Button)({
 	},
 }) as typeof Button;
 
-// hidden navbar items for phase 1
+// TODO: hidden navbar items for phase 1
 const NavbarItems = (): ReactElement => {
 	return (
 	<>

--- a/client/src/components/ServiceCard.tsx
+++ b/client/src/components/ServiceCard.tsx
@@ -4,6 +4,10 @@ import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined';
 import { useHistory } from 'react-router-dom';
 import { CounsellingService } from '../types/counselling-service.types';
 
+// disable ratings and extra info (location, likes, etc.) for phase 1
+const disableRatings = true;
+const disableExtraInfo = true;
+
 type Props = {
 	service: CounsellingService;
 };
@@ -24,14 +28,14 @@ const ServiceCard = ({ service }: Props): ReactElement => {
 				<div className="title">
 					<div className="name">{service.serviceName}</div>
 
-					<div className="ratingItem">
+					{!disableRatings && <div className="ratingItem">
 						<StarOutlineRoundedIcon className="favourite" onClick={() => { }} />
 						<h6 className="rating">{'5.0'}</h6>
 						<h6 className="maxRating">/ 5.0</h6>
 						<ShareOutlinedIcon className="shareIcon"></ShareOutlinedIcon>
-					</div>
+					</div>}
 				</div>
-				<div className="information">
+				{!disableExtraInfo && <div className="information">
 					<ul className="informationList">
 						<li>{service.location}</li>
 						<li>|</li>
@@ -41,7 +45,7 @@ const ServiceCard = ({ service }: Props): ReactElement => {
 						<li>|</li>
 						<li>{'245'} likes</li>
 					</ul>
-				</div>
+				</div>}
 
 				<div className="tags">
 					{tags.map((tag, index) => (

--- a/client/src/components/ServiceCard.tsx
+++ b/client/src/components/ServiceCard.tsx
@@ -4,7 +4,7 @@ import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined';
 import { useHistory } from 'react-router-dom';
 import { CounsellingService } from '../types/counselling-service.types';
 
-// disable ratings and extra info (location, likes, etc.) for phase 1
+// TODO: disabled hardcoded ratings and extra info (location, likes, etc.) for phase 1
 const disableRatings = true;
 const disableExtraInfo = true;
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -65,6 +65,7 @@ div.tags {
   display: flex;
   flex-direction: row;
   justify-content: left;
+  margin-top: 20px;
 }
 
 h6.rating {


### PR DESCRIPTION
## Description
#### Summary:
- Removes placeholder components for phase 1
- Ticket: https://trello.com/c/4XQLob7H/31-hide-placeholder-components

#### Changes:
- Hides unused tabs: sign-in, about, services from Navigation.tsx
- Hides review tab from the full services page 
- Makes the full services page tab with the service name a back button to the home page
- Hides ratings and extra info (likes, location, etc.) in ServiceCard.tsx
- Removes unused routes in App.tsx

#### How to test this PR:
1. Go to home page, navbar only contains "Bring It Up"
2. Service cards only contain the service name and tags
3. Click on a service page to navigate to its full service page, no "Reviews" tab
4. Click on the service name tab, it should both take you back to the home page

## Screenshots:
<img width="1440" alt="Screen Shot 2023-05-20 at 1 31 48 PM" src="https://github.com/bring-it-up/bring-it-up/assets/98232527/4e390c9a-2597-472a-94fe-1a03bcc5d912">
<img width="1440" alt="Screen Shot 2023-05-20 at 1 31 55 PM" src="https://github.com/bring-it-up/bring-it-up/assets/98232527/61a42342-d883-442b-b282-c89bc37bfca5">

## Checklist

- [x] I performed a self-review of my code
